### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/text_summarize/local.settings.json
+++ b/text_summarize/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "TEXT_ANALYTICS_ENDPOINT": "https://<unique-string>.cognitiveservices.azure.com/"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with AI Language Service placeholder settings for local development. Requires `azd provision` first to create resources, then update the endpoint. Uses Entra identity via DefaultAzureCredential (secretless).

## What's included

`text_summarize/local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: python`
- `TEXT_ANALYTICS_ENDPOINT: https://<unique-string>.cognitiveservices.azure.com/`

## Context

Tracked by Azure/azure-functions-templates#TRACKING_ISSUE — ensuring all manifest templates have `local.settings.json` for local development per review feedback.
